### PR TITLE
Fix ftAutoload setting to work with list.

### DIFF
--- a/plugin/hexokinase.vim
+++ b/plugin/hexokinase.vim
@@ -52,7 +52,11 @@ if has('autocmd')
     for event in g:Hexokinase_refreshEvents
       exe 'autocmd '.event.' * call s:on_refresh_event()'
     endfor
-    exe 'autocmd FileType '.join(g:Hexokinase_ftAutoload).' call s:toggle()'
+    if !empty(g:Hexokinase_ftAutoload)
+      for file in g:Hexokinase_ftAutoload
+        exe 'autocmd FileType '.file.' call s:toggle()'
+      endfor
+    endif
   augroup END
 endif
 


### PR DESCRIPTION
As it was the list of files didn't work making the only two options no files (en empty string) or all files ('*').  Implemented a for loop
to allow setting of individual file types.