### PR TITLE
Fix multiple colours in virtual text

### DIFF
--- a/autoload/hexokinase/highlighters/virtual.vim
+++ b/autoload/hexokinase/highlighters/virtual.vim
@@ -12,6 +12,17 @@ fun! hexokinase#highlighters#virtual#highlightv2(bufnr) abort
         let chunks = [[g:Hexokinase_virtualText, it.hlname]]
         if exists('*nvim_buf_get_virtual_text')
             let chunks += nvim_buf_get_virtual_text(a:bufnr, it.lnum - 1)
+        elseif exists('*nvim_buf_get_extmarks')
+            let set_chunks = nvim_buf_get_extmarks(
+                    \   a:bufnr,
+                    \   s:namespace,
+                    \   [it.lnum - 1, 0],
+                    \   [it.lnum - 1, 0],
+                    \   {'details': v:true}
+                    \ )
+            if !empty(set_chunks)
+                let chunks += set_chunks[0][3].virt_text
+            endif
         endif
         call nvim_buf_set_virtual_text(
                     \   a:bufnr,

--- a/doc/hexokinase.txt
+++ b/doc/hexokinase.txt
@@ -149,8 +149,7 @@ Highlighters                                      *g:Hexokinase_highlighters*
 
                 "virtual" will use Neovim's virtual text feature
                 (|nvim_buf_set_virtual_text()|) to display
-                the colour. However, only one colour per line can be
-                displayed.
+                the colour.
 
                 "sign_column" will use the |'sign_column'| to display the
                 colour. In Vim, only one colour per line can be displayed.


### PR DESCRIPTION
In nightly version of neovim since https://github.com/neovim/neovim/commit/49f5b57587ececf37415c64de6224e09baa80f48, `nvim_buf_get_virtual_text` was deleted, so multiple colours are not displayed in the virtual text. This PR fixes the issue by using `nvim_buf_get_extmarks` instead. Besides, it updates the document.