### PR TITLE
Add Windows compatibility

### DIFF
--- a/autoload/hexokinase/utils.vim
+++ b/autoload/hexokinase/utils.vim
@@ -77,6 +77,14 @@ fun! hexokinase#utils#apply_alpha_to_rgb(primary_rgb, alpha) abort
     return [new_r, new_g, new_b]
 endf
 
+fun! hexokinase#utils#separator() abort
+    if has('win32')
+        return ';'
+    else
+        return ':'
+    endif
+endf
+
 fun! hexokinase#utils#tmpname() abort
     let l:clear_tempdir = 0
 

--- a/autoload/hexokinase/v2/scraper.vim
+++ b/autoload/hexokinase/v2/scraper.vim
@@ -137,7 +137,7 @@ fun! s:on_exit(id, status, event) abort dict
 endf
 
 fun! s:parse_colour(line) abort
-    let parts = split(a:line, ':')
+    let parts = split(a:line, hexokinase#utils#separator())
     if len(parts) != 4
         return ''
     endif


### PR DESCRIPTION
Closes #43.

This PR adds Windows compatibility for vim-hexokinase in combination with https://github.com/RRethy/hexokinase/pull/4. The basic idea is to use the directory separator on each operating system to split columns in order that they can reliably be processable.

Currently, the output from hexokinase always looks like in the following in Windows, which results in `len(parts)` being 5 after splitting.

```
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:43:23-29:#2b303b
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:44:14-16:#ff0000
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:44:21-27:#bf616a
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:45:14-18:#008000
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:45:23-29:#a3be8c
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:46:14-19:#ffff00
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:46:24-30:#ebcb8b
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:47:14-17:#0000ff
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:47:22-28:#8fa1b3
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:48:14-19:#800080
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:48:24-30:#b48ead
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:49:14-17:#00ffff
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:49:22-28:#96b5b4
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:50:14-18:#ffffff
C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5:50:23-29:#c0c5ce
```
↓ in Vim
```
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '43', '23-29', '#2b303b']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '44', '14-16', '#ff0000']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '44', '21-27', '#bf616a']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '45', '14-18', '#008000']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '45', '23-29', '#a3be8c']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '46', '14-19', '#ffff00']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '46', '24-30', '#ebcb8b']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '47', '14-17', '#0000ff']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '47', '22-28', '#8fa1b3']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '48', '14-19', '#800080']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '48', '24-30', '#b48ead']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '49', '14-17', '#00ffff']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '49', '22-28', '#96b5b4']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '50', '14-18', '#ffffff']
['C', '\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '50', '23-29', '#c0c5ce']
```
↓ with this patch
```
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '43', '23-29', '#2b303b']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '44', '14-16', '#ff0000']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '44', '21-27', '#bf616a']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '45', '14-18', '#008000']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '45', '23-29', '#a3be8c']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '46', '14-19', '#ffff00']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '46', '24-30', '#ebcb8b']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '47', '14-17', '#0000ff']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '47', '22-28', '#8fa1b3']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '48', '14-19', '#800080']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '48', '24-30', '#b48ead']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '49', '14-17', '#00ffff']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '49', '22-28', '#96b5b4']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '50', '14-18', '#ffffff']
['C:\Users\chitoku\AppData\Local\Temp\nvimHRCcJy\5', '50', '23-29', '#c0c5ce']
```

## Environment

<img src="https://user-images.githubusercontent.com/6535425/105749978-7f8b6e80-5f87-11eb-8f4b-43ad902ff45c.png" width="491">

* Windows 10 (x64)
* Windows Terminal 1.4.3243.0
* Neovim v0.4.4